### PR TITLE
Fix compatibility with Postfix postscreen

### DIFF
--- a/lib/Net/Async/SMTP/Client.pm
+++ b/lib/Net/Async/SMTP/Client.pm
@@ -151,15 +151,17 @@ sub connected {
 			: (),
 		);
 		$self->add_child($stream);
-		$stream->send_greeting->then(sub {
-			return Future->wrap($stream) unless $stream->has_feature('STARTTLS');
+		$stream->startup->then(sub {
+			$stream->send_greeting->then(sub {
+				return Future->wrap($stream) unless $stream->has_feature('STARTTLS');
 
-			# Currently need to have this loaded to find ->sslwrite
-			require IO::Async::SSLStream;
+				# Currently need to have this loaded to find ->sslwrite
+				require IO::Async::SSLStream;
 
-			$stream->starttls(
-				$self->ssl_parameters
-			)
+				$stream->starttls(
+					$self->ssl_parameters
+				)
+			});
 		});
 	});
 }

--- a/lib/Net/Async/SMTP/Connection.pm
+++ b/lib/Net/Async/SMTP/Connection.pm
@@ -42,12 +42,16 @@ sub _add_to_loop {
 		writer => sub { $self->write(@_) },
 		auth_mechanism_override => $self->auth,
 	);
-	$self->protocol->startup;
 	$self->SUPER::_add_to_loop($loop);
 }
 
 sub auth { shift->{auth} }
 sub protocol { shift->{protocol} }
+
+sub startup {
+	my $self = shift;
+	$self->protocol->startup;
+}
 
 sub send_greeting {
 	my $self = shift;


### PR DESCRIPTION
This ensures that the module works with Postfix's [postscreen](https://www.postfix.org/POSTSCREEN_README.html) spam screening functionality.

One of the checks that postscreen does is to banish clients that speak before their turn (see https://www.postfix.org/POSTSCREEN_README.html#pregreet)

This PR changes the sending of the greeting from being immediately the connection has been made, to waiting until the 220 code has been received.